### PR TITLE
refactored vision to use best practices

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -25,10 +25,10 @@ public class Constants {
     public class VisionConstants {
         public static final String TOPRIGHT_CAMERA_NICKNAME = "Microsoft_LifeCam_HD-3000_TopRight";
         public static final Transform3d TOPRIGHT_CAMERA_PLACEMENT = new Transform3d(
-                new Translation3d(0.0285, 0.16, 0.95), new Rotation3d(-Math.PI / 2, 0.44, 0));
+                new Translation3d(0.2015, 0.1920, 0.95), new Rotation3d(-Math.PI / 2, 0.44, 0));
         public static final String BOTTOM_CAMERA_NICKNAME = "Microsoft_LifeCam_HD-3000_Bottom";
         public static final Transform3d BOTTOM_CAMERA_PLACEMENT = new Transform3d(
-                new Translation3d(0.082, 0, 0.134), new Rotation3d(0, 0.35, 0));
+                new Translation3d(0.4383, 0, 0.120), new Rotation3d(0, 0.35 , 0));
 
         public static final PIDController AIMING_PID = new PIDController(0.05, 0, 0.01);
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -23,19 +23,12 @@ public class Constants {
     }
 
     public class VisionConstants {
-        public static final String TOPRIGHT_CAMERA_NICKNAME = "Microsoft_LifeCam_HD-3000_TopRight"; // TODO: find proper
-                                                                                                    // value
+        public static final String TOPRIGHT_CAMERA_NICKNAME = "Microsoft_LifeCam_HD-3000_TopRight";
         public static final Transform3d TOPRIGHT_CAMERA_PLACEMENT = new Transform3d(
-                new Translation3d(0.229, 0.165, 1.003), new Rotation3d())
-                .plus(new Transform3d(new Translation3d(), new Rotation3d(0, 0.44, 0))) // This line to set possible
-                                                                                        // pitch
-                .plus(new Transform3d(new Translation3d(), new Rotation3d(Math.PI / 2, 0, 0))); // This line to set
-                                                                                                // possible yaw,
-        // new Rotation3d(0, 0.959931, 2.61799)
-        public static final String BOTTOM_CAMERA_NICKNAME = "Microsoft_LifeCam_HD-3000_Bottom"; // TODO: find proper
-                                                                                                // value
+                new Translation3d(0.0285, 0.16, 0.95), new Rotation3d(-Math.PI / 2, 0.44, 0));
+        public static final String BOTTOM_CAMERA_NICKNAME = "Microsoft_LifeCam_HD-3000_Bottom";
         public static final Transform3d BOTTOM_CAMERA_PLACEMENT = new Transform3d(
-                new Translation3d(0.26, 0, 0.1708), new Rotation3d(0, 0.35,0));
+                new Translation3d(0.082, 0, 0.134), new Rotation3d(0, 0.35, 0));
 
         public static final PIDController AIMING_PID = new PIDController(0.05, 0, 0.01);
     }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -74,9 +74,7 @@ public class Robot extends TimedRobot {
   public void robotPeriodic() {
     CommandScheduler.getInstance().run();
     // m_robotContainer.updateVisionPose();
-    var pose = m_robotContainer.visionSystem.getEstimatedGlobalPose();
-    if (pose.isPresent()) {
-      m_field.setRobotPose(pose.get().toPose2d());
+    m_field.setRobotPose(m_robotContainer.visionSystem.getEstimatedGlobalPose2d());
   
     SmartDashboard.putNumber("Match Time", Timer.getMatchTime());
     if (!isFMS && DriverStation.isFMSAttached()) {
@@ -84,7 +82,6 @@ public class Robot extends TimedRobot {
       RobotContainer.prettyLights.isFMS();
     }
   }
-}
 
   @Override
   public void disabledInit() {
@@ -92,10 +89,8 @@ public class Robot extends TimedRobot {
 
   @Override
   public void disabledPeriodic() {
-    var pose = m_robotContainer.visionSystem.getEstimatedGlobalPose();
-    if (pose.isPresent()) {
-      m_field.setRobotPose(pose.get().toPose2d());
-    }
+    m_field.setRobotPose(m_robotContainer.visionSystem.getEstimatedGlobalPose2d());
+    
     newAlliance = DriverStation.getAlliance();
     newAutoName = m_robotContainer.getAutonomousCommand().getName();
     if (autoName != newAutoName || alliance != newAlliance) {
@@ -119,9 +114,6 @@ public class Robot extends TimedRobot {
         }
       }
     }
-    if (pose.isPresent()) {
-      m_field.setRobotPose(pose.get().toPose2d());
-    }
   }
 
   @Override
@@ -140,10 +132,7 @@ public class Robot extends TimedRobot {
 
   @Override
   public void autonomousPeriodic() {
-    var pose = m_robotContainer.visionSystem.getEstimatedGlobalPose();
-    if (pose.isPresent()) {
-      m_field.setRobotPose(pose.get().toPose2d());
-    }
+    m_field.setRobotPose(m_robotContainer.visionSystem.getEstimatedGlobalPose2d());
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -17,10 +17,16 @@ import com.pathplanner.lib.path.PathPlannerPath;
 import com.pathplanner.lib.pathfinding.LocalADStar;
 import com.pathplanner.lib.pathfinding.Pathfinding;
 
+import edu.wpi.first.epilogue.Epilogue;
+import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.epilogue.Logged.Strategy;
+import edu.wpi.first.epilogue.logging.FileBackend;
+import edu.wpi.first.epilogue.logging.errors.ErrorHandler;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.net.WebServer;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
@@ -31,13 +37,15 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.subsystems.VisionSystem;
 import frc.utilities.PosUtils;
-
+@Logged(strategy = Strategy.OPT_IN)
 public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
   private String autoName, newAutoName;
   private Optional<Alliance> alliance, newAlliance;
+  @Logged
   public final Field2d m_field = new Field2d();
 
+  @Logged
   private final RobotContainer m_robotContainer;
   public static boolean isFMS = false;
 
@@ -49,6 +57,12 @@ public class Robot extends TimedRobot {
   }
 
   public Robot() {
+    DataLogManager.start("/media/sda1/logs/RIO");
+        Epilogue.configure(config -> {
+            config.backend = new FileBackend(DataLogManager.getLog());
+            config.errorHandler = ErrorHandler.printErrorMessages();
+        });
+        Epilogue.bind(this);
     // startServer();
     m_robotContainer = new RobotContainer();
     Pathfinding.setPathfinder(new LocalADStar());
@@ -143,7 +157,6 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
-
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -57,12 +57,12 @@ public class Robot extends TimedRobot {
   }
 
   public Robot() {
-    DataLogManager.start("/media/sda1/logs/RIO");
-        Epilogue.configure(config -> {
-            config.backend = new FileBackend(DataLogManager.getLog());
-            config.errorHandler = ErrorHandler.printErrorMessages();
-        });
-        Epilogue.bind(this);
+    // DataLogManager.start("/media/sda1/logs/RIO");
+    //     Epilogue.configure(config -> {
+    //         config.backend = new FileBackend(DataLogManager.getLog());
+    //         config.errorHandler = ErrorHandler.printErrorMessages();
+    //     });
+    //     Epilogue.bind(this);
     // startServer();
     m_robotContainer = new RobotContainer();
     Pathfinding.setPathfinder(new LocalADStar());
@@ -73,7 +73,7 @@ public class Robot extends TimedRobot {
   @Override
   public void robotPeriodic() {
     CommandScheduler.getInstance().run();
-    // m_robotContainer.updateVisionPose();
+    m_robotContainer.updateVisionPose(false);
     m_field.setRobotPose(m_robotContainer.visionSystem.getEstimatedGlobalPose2d());
   
     SmartDashboard.putNumber("Match Time", Timer.getMatchTime());
@@ -85,6 +85,7 @@ public class Robot extends TimedRobot {
 
   @Override
   public void disabledInit() {
+    m_robotContainer.updateVisionPose(true);
   }
 
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -260,11 +260,7 @@ public class RobotContainer {
     private final SendableChooser<Command> autoChooser;
 
     public RobotContainer() {
-        DataLogManager.start("/media/sda1/logs/RIO");
-        Epilogue.configure(config -> {
-            config.backend = new FileBackend(DataLogManager.getLog());
-            config.errorHandler = ErrorHandler.printErrorMessages();
-        });
+        
 
         if (isButtonBox) {
             buttonBox = new ButtonBox(1);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -419,12 +419,15 @@ public class RobotContainer {
     }
 
     public void updateVisionPose() {
-        var pose = visionSystem.getEstimatedGlobalPose();
-        if (pose.isPresent() && drivetrain.getStateCopy().Speeds.vxMetersPerSecond <= 0.5
-                && drivetrain.getStateCopy().Speeds.vyMetersPerSecond <= 0.5) {
+        var speeds = drivetrain.getStateCopy().Speeds;
+
+        var velX = Math.abs(speeds.vxMetersPerSecond); 
+        var velY = Math.abs(speeds.vyMetersPerSecond); 
+        var velAngular = Math.abs(speeds.omegaRadiansPerSecond);
+
+        if (velX <= 0.5 && velY <= 0.5 && velAngular <= Math.PI) {
             double visionTime = visionSystem.getTimeStamp();
-            drivetrain.addVisionMeasurement(pose.get().toPose2d(), visionTime);
-            drivetrain.resetPose(pose.get().toPose2d());
+            drivetrain.addVisionMeasurement(visionSystem.getEstimatedGlobalPose2d(), visionTime);
         }
     }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -418,7 +418,7 @@ public class RobotContainer {
         return speed * modifier;
     }
 
-    public void updateVisionPose() {
+    public void updateVisionPose(boolean reset_pose) {
         var speeds = drivetrain.getStateCopy().Speeds;
 
         var velX = Math.abs(speeds.vxMetersPerSecond); 
@@ -427,7 +427,13 @@ public class RobotContainer {
 
         if (velX <= 0.5 && velY <= 0.5 && velAngular <= Math.PI) {
             double visionTime = visionSystem.getTimeStamp();
-            drivetrain.addVisionMeasurement(visionSystem.getEstimatedGlobalPose2d(), visionTime);
+            if(visionTime != 0) {
+                drivetrain.addVisionMeasurement(visionSystem.getEstimatedGlobalPose2d(), visionTime);
+                if(reset_pose)
+                {
+                    drivetrain.resetPose(visionSystem.getEstimatedGlobalPose2d());
+                }
+            }
         }
     }
 

--- a/src/main/java/frc/robot/subsystems/DriveSystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSystem.java
@@ -16,6 +16,7 @@ import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import com.pathplanner.lib.path.PathConstraints;
 
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.epilogue.Logged.Strategy;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -43,6 +44,7 @@ import frc.robot.generated.AlphaTunerConstants.TunerSwerveDrivetrain;
 @Logged(strategy = Strategy.OPT_OUT)
 public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
     private static final double kSimLoopPeriod = 0.005; // 5 ms
+    @NotLogged
     private Notifier m_simNotifier = null;
     private double m_lastSimTime;
 
@@ -54,11 +56,15 @@ public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
     private boolean m_hasAppliedOperatorPerspective = false;
 
     /** Swerve request to apply during robot-centric path following */
+    @NotLogged
     private final SwerveRequest.ApplyRobotSpeeds m_pathApplyRobotSpeeds = new SwerveRequest.ApplyRobotSpeeds();
 
     /* Swerve requests to apply during SysId characterization */
+    @NotLogged
     private final SwerveRequest.SysIdSwerveTranslation m_translationCharacterization = new SwerveRequest.SysIdSwerveTranslation();
+    @NotLogged
     private final SwerveRequest.SysIdSwerveSteerGains m_steerCharacterization = new SwerveRequest.SysIdSwerveSteerGains();
+    @NotLogged
     private final SwerveRequest.SysIdSwerveRotation m_rotationCharacterization = new SwerveRequest.SysIdSwerveRotation();
     private final Field2d field = new Field2d();
 
@@ -70,6 +76,7 @@ public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
      * SysId routine for characterizing translation. This is used to find PID gains
      * for the drive motors.
      */
+    @NotLogged
     private final SysIdRoutine m_sysIdRoutineTranslation = new SysIdRoutine(
             new SysIdRoutine.Config(
                     null, // Use default ramp rate (1 V/s)
@@ -86,6 +93,7 @@ public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
      * SysId routine for characterizing steer. This is used to find PID gains for
      * the steer motors.
      */
+    @NotLogged
     private final SysIdRoutine m_sysIdRoutineSteer = new SysIdRoutine(
             new SysIdRoutine.Config(
                     null, // Use default ramp rate (1 V/s)
@@ -105,6 +113,7 @@ public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
      * See the documentation of SwerveRequest.SysIdSwerveRotation for info on
      * importing the log to SysId.
      */
+    @NotLogged
     private final SysIdRoutine m_sysIdRoutineRotation = new SysIdRoutine(
             new SysIdRoutine.Config(
                     /* This is in radians per second², but SysId only supports "volts per second" */
@@ -125,6 +134,7 @@ public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
                     this));
 
     /* The SysId routine to test */
+    @NotLogged
     private SysIdRoutine m_sysIdRoutineToApply = m_sysIdRoutineTranslation;
 
     /**
@@ -374,10 +384,11 @@ public class DriveSystem extends TunerSwerveDrivetrain implements Subsystem {
      * @param timestampSeconds      The timestamp of the vision measurement in
      *                              seconds.
      */
-    @Override
-    public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
-        super.addVisionMeasurement(visionRobotPoseMeters, Utils.fpgaToCurrentTime(timestampSeconds));
-    }
+    // @Override
+    // TODO: just dont override this
+    // public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    //     super.addVisionMeasurement(visionRobotPoseMeters, Utils.fpgaToCurrentTime(timestampSeconds));
+    // }
 
     /**
      * Adds a vision measurement to the Kalman Filter. This will correct the

--- a/src/main/java/frc/robot/subsystems/VisionSystem.java
+++ b/src/main/java/frc/robot/subsystems/VisionSystem.java
@@ -213,7 +213,12 @@ public class VisionSystem extends SubsystemBase {
 
   @NotLogged
   public double getTimeStamp() {
-    return getEstimatedGlobalPose().timestampSeconds;
+    if (getEstimatedGlobalPose() != null) {
+      return getEstimatedGlobalPose().timestampSeconds;  
+    }
+    else {
+      return 0.0;
+    }
   }
 
   /*
@@ -382,13 +387,13 @@ public class VisionSystem extends SubsystemBase {
 
     LEDPattern pattern = LEDPattern.solid(Color.kGreen);
 
-    if (hasTag) {
-      if (!prettyLights.hasTopPattern("Has Tag")) {
-        prettyLights.addTopPattern("Has Tag", 10, pattern);
-      }
+    // if (hasTag) {
+    //   if (!prettyLights.hasTopPattern("Has Tag")) {
+    //     prettyLights.addTopPattern("Has Tag", 10, pattern);
+    //   }
 
-    } else {
-      prettyLights.removeTopPattern("Has Tag");
-    }
+    // } else {
+    //   prettyLights.removeTopPattern("Has Tag");
+    // }
   }
 }

--- a/src/main/java/frc/robot/subsystems/VisionSystem.java
+++ b/src/main/java/frc/robot/subsystems/VisionSystem.java
@@ -387,13 +387,13 @@ public class VisionSystem extends SubsystemBase {
 
     LEDPattern pattern = LEDPattern.solid(Color.kGreen);
 
-    // if (hasTag) {
-    //   if (!prettyLights.hasTopPattern("Has Tag")) {
-    //     prettyLights.addTopPattern("Has Tag", 10, pattern);
-    //   }
+    if (hasTag) {
+      if (!prettyLights.hasTopPattern("Has Tag")) {
+        prettyLights.addTopPattern("Has Tag", 10, pattern);
+      }
 
-    // } else {
-    //   prettyLights.removeTopPattern("Has Tag");
-    // }
+    } else {
+      prettyLights.removeTopPattern("Has Tag");
+    }
   }
 }


### PR DESCRIPTION
replaced all instances of the deprecated `getLatestResult` with the newer `getAllUnreadResults`, according to what is recommended in the documentation. This also required refactoring to store the latest result for use in various other functions that require it. This also allows `getEstimatedPose` to always return a pose, as it can now never be null (except in initialization). also removed the line that was overwriting the drivebase pose with the vision pose to properly combine the two with a filter.

